### PR TITLE
Adding default_content_type config value

### DIFF
--- a/src/XeroPHP/Application.php
+++ b/src/XeroPHP/Application.php
@@ -16,6 +16,7 @@ class Application
     protected static $_config_defaults = [
         'xero' => [
             'base_url' => 'https://api.xero.com/',
+            'default_content_type' => Request::CONTENT_TYPE_XML,
 
             'core_version' => '2.0',
             'payroll_version' => '1.0',

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -79,7 +79,7 @@ class Request
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
-        $this->setHeader(self::HEADER_ACCEPT, $app->getConfig('default_content_type'));
+        $this->setHeader(self::HEADER_ACCEPT, $app->getConfigOption('xero', 'default_content_type'));
 
         $xero_config = $this->app->getConfig('xero');
         if (isset($xero_config['unitdp'])) {

--- a/src/XeroPHP/Remote/Request.php
+++ b/src/XeroPHP/Remote/Request.php
@@ -79,7 +79,7 @@ class Request
         }
 
         //Default to XML so you get the  xsi:type attribute in the root node.
-        $this->setHeader(self::HEADER_ACCEPT, self::CONTENT_TYPE_XML);
+        $this->setHeader(self::HEADER_ACCEPT, $app->getConfig('default_content_type'));
 
         $xero_config = $this->app->getConfig('xero');
         if (isset($xero_config['unitdp'])) {


### PR DESCRIPTION
Adding default_content_type config value to the Application, which can be used to override the default value for the Accept HTTP header.

The context here is that this library has always sent `Accept: text/xml` by default; in the past the Xero API ignored this and returned JSON anyway. It looks like the API now respects the `Accept` header so we'd like override the default value and request JSON.