### PR TITLE
XM-2631 Fix AU Pay Template

### DIFF
--- a/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
+++ b/src/XeroPHP/Models/PayrollAU/Employee/PayTemplate.php
@@ -105,9 +105,9 @@ class PayTemplate extends Remote\Model
         return [
             'EarningsLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\EarningsLine', true, false],
             'DeductionLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\DeductionLine', true, false],
-            'SuperLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\SuperLine', false, false],
+            'SuperLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\SuperLine', true, false],
             'ReimbursementLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\ReimbursementLine', true, false],
-            'LeaveLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\LeaveLine', false, false],
+            'LeaveLines' => [false, self::PROPERTY_TYPE_OBJECT, 'PayrollAU\\Employee\\PayTemplate\\LeaveLine', true, false],
         ];
     }
 


### PR DESCRIPTION
See https://github.com/calcinai/xero-php/issues/841

In summary, we need the `PayTemplate.LeaveLines.EntitlementFinalPayPayoutType` value from the `Employees` table in MongoDB, in order to complete [XM-2384](https://receiptbank.atlassian.net/browse/XM-2384). The issue we came across was that `LeaveLines` was only ever an empty array for AU.

This work resolves this issue, and `LeaveLines` (and `SuperLines`) now returns an array of expected values.

Before:

![image](https://user-images.githubusercontent.com/84777922/151787658-3cc886be-845c-46f7-b9c8-7fde6fb55fb9.png)


After:

![Screenshot 2022-01-31 at 11 35 31](https://user-images.githubusercontent.com/84777922/151787507-48b5fdc2-09da-495f-8f05-f8220ae7967b.png)

**Testing**

To require feature branch:
```
devenv composer require calcinai/xero-php:dev-XM-2384-fix-AU-pay-template
```

To populate Employees table:
- Set Team (must be a dext team) location to AU (teams.location in DB) 
- Create & import AU Demo Company from Xero
- Enable payroll feature flag (payroll-au)
- Enable 2FA for user (users.uses_two_factor_auth in DB)
- Navigate to Client > Insights > Payroll to enable Payroll for client
- Sync client & you should now see data in the employees table in Mongo :slight_smile: 