### PR TITLE
XM-2859 Pass more data for the logging of SimpleXMLException

### DIFF
--- a/src/XeroPHP/Remote/Exception/SimpleXMLException.php
+++ b/src/XeroPHP/Remote/Exception/SimpleXMLException.php
@@ -14,7 +14,7 @@ class SimpleXMLException extends Exception
     {
         $this->_data = $data;
         $this->_xmlHeaderContentLength = $xmlContentLength ?? 0;
-        $this->_xmlLength = count($data) ?? 0;
+        $this->_xmlLength = strlen($data) ?? 0;
         parent::__construct($message);
     }
 

--- a/src/XeroPHP/Remote/Exception/SimpleXMLException.php
+++ b/src/XeroPHP/Remote/Exception/SimpleXMLException.php
@@ -7,15 +7,29 @@ use XeroPHP\Remote\Exception;
 class SimpleXMLException extends Exception 
 {
     private $_data = '';
+    private $_xmlHeaderContentLength = 0;
+    private $_xmlLength = 0;
 
-    public function __construct($message, $data) 
+    public function __construct($message, $data, $xmlContentLength = null) 
     {
         $this->_data = $data;
+        $this->_xmlHeaderContentLength = $xmlContentLength ?? 0;
+        $this->_xmlLength = count($data) ?? 0;
         parent::__construct($message);
     }
 
     public function getData()
     {
         return $this->_data;
+    }
+
+    public function getXmlContentLength()
+    {
+        return $this->_xmlHeaderContentLength;
+    }
+
+    public function getXmlLength()
+    {
+        return $this->_xmlLength;
     }
 }

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -312,7 +312,11 @@ class Response
         try {
             $sxml = new SimpleXMLElement($this->response_body);
         } catch(Throwable $exception) {
-            throw new SimpleXMLException($exception->getMessage(), $this->response_body);
+            throw new SimpleXMLException(
+                $exception->getMessage(),
+                $this->response_body,
+                $this->headers[Request::HEADER_CONTENT_LENGTH]
+            );
         }
 
         // Fixed Asset Settings are special snowflakes


### PR DESCRIPTION
In order to determine whether or not we are receiving the complete xml dump on Precision, we need to know what the content length header and/or character count of the xml was prior to it being sent to Precision.