### PR TITLE
XM-2954 Fix broken xml with tidy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "guzzlehttp/guzzle": "^6.5",
     "guzzlehttp/psr7": "^1.5",
     "ext-json": "*",
-    "ext-simplexml": "*"
+    "ext-simplexml": "*",
+    "ext-tidy": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5"

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -314,15 +314,22 @@ class Response
             $sxml = new SimpleXMLElement($this->response_body);
         } catch(Throwable $exception) {
             // Try to fix the unparsable XML using Tidy
+            // The 'numeric-entities' => false, will decode entities into characters
+            // then the preg_replace will remove the control characters
             try {
                 $tidy = new Tidy();
+            
                 $config = [
                     'output-xml'     => true,
                     'input-xml'     => true,
                     'numeric-entities' => false,
                 ];
+
                 $xml = $tidy->repairString($this->response_body, $config);
+
+                // This line removes the non printable characters which are causing the issue
                 $xml = preg_replace('/[^[:print:]\n\t]/u', '', $xml);
+
                 $sxml = new SimpleXMLElement($xml);
             } catch(Throwable $exception) {
                 throw new SimpleXMLException(


### PR DESCRIPTION
Ryan identified a potential fix for our XML issues by using Tidy to clean up the XML prior to passing it to SimpleXML. This PR introduces Ryan's suggested changes.

PR is in draft as we first need to ensure Production and our docker images etc have Tidy installed before we can release this fix. @matthewswain has kindly offered to take that on!