### PR TITLE
Parse warnings from XML responses

### DIFF
--- a/src/XeroPHP/Remote/Query.php
+++ b/src/XeroPHP/Remote/Query.php
@@ -38,6 +38,8 @@ class Query
 
     private $params;
 
+    private $warnings;
+
     public function __construct(Application $app)
     {
         $this->app = $app;
@@ -49,6 +51,7 @@ class Query
         $this->includeArchived = false;
         $this->createdByMyApp = false;
         $this->params = [];
+        $this->warnings = [];
     }
 
     /**
@@ -331,8 +334,11 @@ class Query
 
         $request->send();
 
+        $response = $request->getResponse();
+        $this->warnings = $response->getRootWarnings();
+
         $elements = new Collection();
-        foreach ($request->getResponse()->getElements() as $element) {
+        foreach ($response->getElements() as $element) {
             /**
              * @var Model
              */
@@ -342,6 +348,11 @@ class Query
         }
 
         return $elements;
+    }
+
+    public function getWarnings()
+    {
+        return $this->warnings;
     }
 
     public function first()

--- a/src/XeroPHP/Remote/Response.php
+++ b/src/XeroPHP/Remote/Response.php
@@ -75,6 +75,8 @@ class Response
 
     private $root_error;
 
+    private $root_warnings;
+
     public function __construct(Request $request, $response_body, $status, $headers)
     {
         $this->request = $request;
@@ -228,6 +230,11 @@ class Response
         return $this->root_error;
     }
 
+    public function getRootWarnings()
+    {
+        return $this->root_warnings;
+    }
+
     public function getOAuthResponse()
     {
         return $this->oauth_response;
@@ -239,6 +246,7 @@ class Response
         $this->element_errors = [];
         $this->element_warnings = [];
         $this->root_error = [];
+        $this->root_warnings = [];
 
         if (!isset($this->headers[Request::HEADER_CONTENT_TYPE])) {
             //Nothing to parse
@@ -364,6 +372,13 @@ class Response
                     break;
                 case 'Message':
                     $this->root_error['message'] = (string)$root_child;
+
+                    break;
+                case 'Warnings':
+                    $this->root_warnings = [];
+                    foreach ($root_child->children() as $element_index => $element) {
+                        $this->root_warnings[] = Helpers::XMLToArray($element);
+                    }
 
                     break;
                 case 'Payslip':


### PR DESCRIPTION
What            | Where/Who
----------------|----------------------------------------
Issue           | 
Stakeholders    |
Reviewers       | @Bittarman @georgi-razsolkov @arunas-dilius-dext 

## Background

Developer update from Xero says:

> We will be enforcing high volume threshold limits to key endpoints in the Accounting API from the 1st of September 2024.

And in their documentation they state

> We currently append a warning message to the payload of requests that exceed the limit, to notify clients and encourage them to take preventive measures. For instance, please see the example payload with a warning message for the Invoices endpoint below. If you have received this message, you should follow the advice above.

With the example

```json
{
  "Id": <GUID>,
  "Status": "OK",
  "ProviderName": <Name>,
  "DateTimeUTC": <Date>,
  "Invoices": [...],
  "Warnings": [
    {
	    "Message": "Your request is not filtering invoices efficiently, given the extremely high volume for this organisation. Please be aware that we will soon be enforcing a high volume threshold limit, which will result in this request returning an error in the future. Please check https://developer.xero.com/documentation/api/efficient-data-retrieval for tips on how to make invoices retrieval more efficient."
    }
  ]
}
```

## Implementation Notes

This change will make the warnings available to xavier so that they can be logged.

I've chosen to store these warnings on the`Query` object. At first glance using the `Response` object directly might make more sense, but the xavier codebase uses `Query::execute` and that method never exposes the `Response` object. I wanted to minimize the changes to the `xero-php` API and felt that adding a new `Query::getWarnings` method was preferable vs. changing the return value of `Query::execute`/exposing the `Response` object.